### PR TITLE
Remove HOME var from env.variables

### DIFF
--- a/fes-batch/backup-clear-down/backup-clear-down.sh
+++ b/fes-batch/backup-clear-down/backup-clear-down.sh
@@ -2,10 +2,8 @@
 
 cd /apps/fes/backup-clear-down
 
-# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
-KEEP_HOME=${HOME}
+# load variables created from setCron script
 source /apps/fes/env.variables
-HOME=${KEEP_HOME}
 
 # Set up mail config for msmtp & load alerting functions
 envsubst <../.msmtprc.template >../.msmtprc

--- a/fes-batch/batch-clear-down/batch-clear-down.sh
+++ b/fes-batch/batch-clear-down/batch-clear-down.sh
@@ -17,10 +17,8 @@
 
 cd /apps/fes/batch-clear-down
 
-# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
-KEEP_HOME=${HOME}
+# load variables created from setCron script
 source /apps/fes/env.variables
-HOME=${KEEP_HOME}
 
 # create properties file and substitutes values
 envsubst <batch-clear-down.properties.template >batch-clear-down.properties

--- a/fes-batch/fes-file-loader/fes-file-loader.sh
+++ b/fes-batch/fes-file-loader/fes-file-loader.sh
@@ -2,10 +2,8 @@
 
 cd /apps/fes/fes-file-loader
 
-# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
-KEEP_HOME=${HOME}
+# load variables created from setCron script
 source /apps/fes/env.variables
-HOME=${KEEP_HOME}
 
 # create properties file and substitutes values
 envsubst < fes-file-loader.properties.template > fes-file-loader.properties

--- a/fes-batch/monitoring/batch-status.sh
+++ b/fes-batch/monitoring/batch-status.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 cd /apps/fes/monitoring
-# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
-KEEP_HOME=${HOME}
+# load variables created from setCron script
 source /apps/fes/env.variables
-HOME=${KEEP_HOME}
 
 # Set up mail config for msmtp & load alerting functions
 envsubst <../.msmtprc.template >../.msmtprc

--- a/fes-batch/monitoring/fes-check.sh
+++ b/fes-batch/monitoring/fes-check.sh
@@ -2,10 +2,8 @@
 
 cd /apps/fes/monitoring
 
-# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
-KEEP_HOME=${HOME}
+# load variables created from setCron script
 source /apps/fes/env.variables
-HOME=${KEEP_HOME}
 
 # Set up mail config for msmtp & load alerting functions
 envsubst <../.msmtprc.template >../.msmtprc

--- a/fes-batch/monitoring/hung-batch.sh
+++ b/fes-batch/monitoring/hung-batch.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 cd /apps/fes/monitoring
-# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
-KEEP_HOME=${HOME}
+# load variables created from setCron script
 source /apps/fes/env.variables
-HOME=${KEEP_HOME}
 
 # Set up mail config for msmtp & load alerting functions
 envsubst <../.msmtprc.template >../.msmtprc

--- a/fes-batch/monitoring/too-many-batches.sh
+++ b/fes-batch/monitoring/too-many-batches.sh
@@ -2,10 +2,8 @@
 
 cd /apps/fes/monitoring
 
-# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
-KEEP_HOME=${HOME}
+# load variables created from setCron script
 source /apps/fes/env.variables
-HOME=${KEEP_HOME}
 
 # Set up mail config for msmtp & load alerting functions
 envsubst <../.msmtprc.template >../.msmtprc

--- a/fes-batch/move-scan-files/move-scan-files.sh
+++ b/fes-batch/move-scan-files/move-scan-files.sh
@@ -2,10 +2,8 @@
 
 cd /apps/fes/move-scan-files
 
-# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
-KEEP_HOME=${HOME}
+# load variables created from setCron script
 source /apps/fes/env.variables
-HOME=${KEEP_HOME}
 
 # Set up mail config for msmtp & load alerting functions
 envsubst <../.msmtprc.template >../.msmtprc

--- a/fes-batch/scripts/track-crontab-changes.sh
+++ b/fes-batch/scripts/track-crontab-changes.sh
@@ -2,10 +2,8 @@
 
 cd ${HOME}/scripts
 
-# load variables created from setCron script - being careful not to overwrite HOME as msmtp mail process uses it to find config
-KEEP_HOME=${HOME}
+# load variables created from setCron script
 source ${HOME}/env.variables
-HOME=${KEEP_HOME}
 
 # Set up mail config for msmtp & load alerting functions
 envsubst < ${HOME}/.msmtprc.template > ${HOME}/.msmtprc

--- a/fes-batch/setCron.sh
+++ b/fes-batch/setCron.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# sed command to add export to beginning of each line and quote values
-env | sed 's/^/export /;s/=/&"/;s/$/"/' > /apps/fes/env.variables
+# sed command to remove ref to wrong HOME dir, add export to beginning of each line, and quote values
+env | sed '/^HOME=/d;s/^/export /;s/=/&"/;s/$/"/' > /apps/fes/env.variables
 
 # set fes user crontab
 su -c 'crontab /apps/fes/cron/crontab.txt' fes


### PR DESCRIPTION
Removing workaround code to preserve the value of HOME when sourcing env.variables, and instead removing the var when the file is created.

HOME var is removed but e.g. JAVA_HOME or HOME_XX are preserved.