### PR TITLE
Add QIA scripts

### DIFF
--- a/fes-batch/qia/qia-cleardown.sh
+++ b/fes-batch/qia/qia-cleardown.sh
@@ -16,19 +16,16 @@ cd /apps/fes/qia
 # load variables created from setCron script
 source /apps/fes/env.variables
 
-# Set up alerting functions
-source ../scripts/alert_functions
-
 # set up logging
-LOGS_DIR=../logs/qia-done-cleardown
+LOGS_DIR=../logs/qia-cleardown
 mkdir -p ${LOGS_DIR}
-LOG_FILE="${LOGS_DIR}/${HOSTNAME}-qia-done-cleardown-$(date +'%Y-%m-%d_%H-%M-%S').log"
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-qia-cleardown-$(date +'%Y-%m-%d_%H-%M-%S').log"
 source /apps/fes/scripts/logging_functions
 
 exec >>${LOG_FILE} 2>&1
 
 f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-f_logInfo "Starting qia-done-cleardown"
+f_logInfo "Starting qia-cleardown"
 
 rm -r /apps/fes/qia/breaches/Release/1*
 rm -r /apps/fes/qia/breaches/Release/2*
@@ -40,4 +37,4 @@ rm -r /apps/fes/qia/breaches/Release/7*
 rm -r /apps/fes/qia/breaches/Release/8*
 rm -r /apps/fes/qia/breaches/Release/9*
 
-f_logInfo "qia-done-cleardown completed"
+f_logInfo "qia-cleardown completed"

--- a/fes-batch/qia/qia-done-cleardown.sh
+++ b/fes-batch/qia/qia-done-cleardown.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# This script forms part of the manual QIA sanity checking process where certain scanned images are reviewed by humans. 
+# Images needing review are placed in a Work folder automatically by the qia-run.sh script.
+# After those images are reviewed and if no issues are found, they are manually moved to a Release folder.
+# If an issue is found, the images are manually moved to an Identified_Breach folder. 
+# 
+# This script removes files in the /apps/fes/qia/breaches/Release folder.  The folder /apps/fes/qia/breaches is
+# a filesystem location external to the chips-fes-batch container that has been bind mounted into the container as /apps/fes/qia/breaches
+# The files are removed only inside the Release subfolder, as that is the location where files have been moved after manual checking.
+#
+# This script is expected to run in the evening to clear down files in Release ready for the next day.
+
+cd /apps/fes/qia
+
+# load variables created from setCron script
+source /apps/fes/env.variables
+
+# Set up alerting functions
+source ../scripts/alert_functions
+
+# set up logging
+LOGS_DIR=../logs/qia-done-cleardown
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-qia-done-cleardown-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/fes/scripts/logging_functions
+
+exec >>${LOG_FILE} 2>&1
+
+f_logInfo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+f_logInfo "Starting qia-done-cleardown"
+
+rm -r /apps/fes/qia/breaches/Release/1*
+rm -r /apps/fes/qia/breaches/Release/2*
+rm -r /apps/fes/qia/breaches/Release/3*
+rm -r /apps/fes/qia/breaches/Release/4*
+rm -r /apps/fes/qia/breaches/Release/5*
+rm -r /apps/fes/qia/breaches/Release/6*
+rm -r /apps/fes/qia/breaches/Release/7*
+rm -r /apps/fes/qia/breaches/Release/8*
+rm -r /apps/fes/qia/breaches/Release/9*
+
+f_logInfo "qia-done-cleardown completed"

--- a/fes-batch/qia/qia-run.sh
+++ b/fes-batch/qia/qia-run.sh
@@ -11,7 +11,7 @@
 # This script carries out the following steps:
 #  1. queries a database (via SSH and SCP) to obtain a list of scanned images that need manual review
 #  2. looks for a corresponding folder in /apps/fes/qia/images for each image:
-#  2.a  if found skips and checks next image
+#  2.a  if found, skips this image and moves on to check next image
 #  2.b  if not found, creates the folder and then copies the image from the image server to the /apps/fes/qia/breaches folder
 #
 

--- a/fes-batch/qia/qia-run.sh
+++ b/fes-batch/qia/qia-run.sh
@@ -1,74 +1,104 @@
 #!/bin/bash
 
-local_image_dir=/apps/fes/qia/images
-dps_image_dir=/apps/fes/qia/breaches/Work
-image_user=${QIA_IMAGE_USER}
-image_server=${QIA_IMAGE_SERVER}
-image_user_server=${image_user}@${image_server}
-db_query_script=./db_queryqia
-db_query_output=/tmp/mw_unload
-barcode_list=barcodes.out
+# This script forms part of the manual QIA sanity checking process where certain scanned images are reviewed by humans. 
+# Images needing review are placed in a Work folder automatically by this script.
+# After those images are reviewed and if no issues are found, they are manually moved to a Release folder.
+# If an issue is found, the images are manually moved to an Identified_Breach folder.
+
+# The folder /apps/fes/qia/breaches is a filesystem location external to the chips-fes-batch container 
+# that has been bind mounted into the container as /apps/fes/qia/breaches
+#
+# This script carries out the following steps:
+#  1. queries a database (via SSH and SCP) to obtain a list of scanned images that need manual review
+#  2. looks for a corresponding folder in /apps/fes/qia/images for each image:
+#  2.a  if found skips and checks next image
+#  2.b  if not found, creates the folder and then copies the image from the image server to the /apps/fes/qia/breaches folder
+#
 
 cd /apps/fes/qia
 
+# load variables created from setCron script
+source /apps/fes/env.variables
+
+# set up logging
+LOGS_DIR=../logs/qia-run
+mkdir -p ${LOGS_DIR}
+LOG_FILE="${LOGS_DIR}/${HOSTNAME}-qia-run-$(date +'%Y-%m-%d_%H-%M-%S').log"
+source /apps/fes/scripts/logging_functions
+
+exec >>${LOG_FILE} 2>&1
+
+LOCAL_IMAGE_DIR=/apps/fes/qia/images
+DPS_IMAGE_DIR=/apps/fes/qia/breaches/Work
+IMAGE_USER=${QIA_IMAGE_USER}
+IMAGE_SERVER=${QIA_IMAGE_SERVER}
+IMAGE_USER_server=${IMAGE_USER}@${IMAGE_SERVER}
+DB_QUERY_SCRIPT=./db_queryqia
+DB_QUERY_OUTPUT=/tmp/mw_unload
+BARCODE_LIST=barcodes.out
+KEY_FOLDER=/apps/fes/.ssh
+
+# Set up SSH key if not already present
+if [ ! -f ${KEY_FOLDER}/${QIA_KEY_FILE} ]; then
+  mkdir -p ${KEY_FOLDER}
+  chmod 0700 ${KEY_FOLDER}
+  echo -e ${QIA_KEY} > ${KEY_FOLDER}/${QIA_KEY_FILE}
+  chmod 0600 ${KEY_FOLDER}/${QIA_KEY_FILE}
+fi
+
 # Obtain list of form barcodes that have not yet been through sort
-date
-echo "Querying for outstanding barcodes"
-# TODO - use key file
-ssh ${image_user_server} ${db_query_script}
-scp ${image_user_server}:${db_query_output} ${barcode_list} 
-sed -i 's/ $//g' ${barcode_list}
-sed -i 's/ /:/g' ${barcode_list}
+f_logInfo "Querying for outstanding barcodes"
 
-echo
-date
-echo "Query for outstanding barcodes completed"
-wc -l ${barcode_list}
+ssh -o StrictHostKeychecking=no -o UserKnownHostsFile=/dev/null -i ${KEY_FOLDER}/${QIA_KEY_FILE} ${IMAGE_USER_server} ${DB_QUERY_SCRIPT}
+scp -o StrictHostKeychecking=no -o UserKnownHostsFile=/dev/null -i ${KEY_FOLDER}/${QIA_KEY_FILE} ${IMAGE_USER_server}:${DB_QUERY_OUTPUT} ${BARCODE_LIST} 
+sed -i 's/ $//g' ${BARCODE_LIST}
+sed -i 's/ /:/g' ${BARCODE_LIST}
 
-# Iterate through list - checking if we already have the images
-for four_fields in `cat ${barcode_list}`
+f_logInfo "Query for outstanding barcodes completed"
+wc -l ${BARCODE_LIST}
+
+# Iterate through list - checking if we already have the image folders locally
+# If we don't have the folder we haven't copied it over to the QIA Work folder yet
+for FOUR_FIELDS in `cat ${BARCODE_LIST}`
 do
 
- batch_barcode=${four_fields%%:*}
+ BATCH_BARCODE=${FOUR_FIELDS%%:*}
 
- three_fields=${four_fields#*:}
- form_barcode=${three_fields%%:*}
+ THREE_FIELDS=${FOUR_FIELDS#*:}
+ FORM_BARCODE=${THREE_FIELDS%%:*}
 
- two_fields=${three_fields#*:}
- company_num=${two_fields%%:*}
+ TWO_FIELDS=${THREE_FIELDS#*:}
+ COMPANY_NUM=${TWO_FIELDS%%:*}
 
- doc_type=${two_fields##*:}
+ DOC_TYPE=${TWO_FIELDS##*:}
 
- date
- echo "Processing batch ${batch_barcode} document ${form_barcode} company ${company_num} type ${doc_type}"
-
+ f_logInfo "Processing batch ${BATCH_BARCODE} document ${FORM_BARCODE} company ${COMPANY_NUM} type ${DOC_TYPE}"
 
  # Ensure batch folder exists
- batch_folder=${local_image_dir}/${batch_barcode}
- mkdir -p ${batch_folder}
- qia_folder=${dps_image_dir}/${batch_barcode}_${form_barcode}_${company_num}_${doc_type}
+ BATCH_FOLDER=${LOCAL_IMAGE_DIR}/${BATCH_BARCODE}
+ mkdir -p ${BATCH_FOLDER}
+ QIA_FOLDER=${DPS_IMAGE_DIR}/${BATCH_BARCODE}_${FORM_BARCODE}_${COMPANY_NUM}_${DOC_TYPE}
 
  # Path to form image folder
- form_image_folder_path=${batch_folder}/${form_barcode}
+ FORM_IMAGE_FOLDER_PATH=${BATCH_FOLDER}/${FORM_BARCODE}
 
  # Does form image folder exist - if not, copy images
- if [ ! -d ${form_image_folder_path} ]; then
+ if [ ! -d ${FORM_IMAGE_FOLDER_PATH} ]; then
 
-   mkdir -p ${qia_folder}
-   chmod 777 ${qia_folder}
+   mkdir -p ${QIA_FOLDER}
+   chmod 777 ${QIA_FOLDER}
 
-   echo "${batch_barcode}${form_barcode}${company_num}${doc_type} Existing image folder not found: ${form_image_folder_path}"
-   echo "${batch_barcode}${form_barcode}${company_num}${doc_type}  Getting image from ${image_user_server}:/image/*/day1/${batch_barcode}/${form_barcode}"
+   f_logInfo "${BATCH_BARCODE}${FORM_BARCODE}${COMPANY_NUM}${DOC_TYPE} Existing image folder not found: ${FORM_IMAGE_FOLDER_PATH}"
+   f_logInfo "${BATCH_BARCODE}${FORM_BARCODE}${COMPANY_NUM}${DOC_TYPE} Copying images from ${IMAGE_USER_server}:/image/*/day1/${BATCH_BARCODE}/${FORM_BARCODE} to ${QIA_FOLDER}"
  
-   mkdir -p ${form_image_folder_path}
-   #scp -r ${image_user_server}:/image/*/day1/${batch_barcode}/${form_barcode}/*.TIF ${qia_folder}
+   mkdir -p ${FORM_IMAGE_FOLDER_PATH}
+   scp -o StrictHostKeychecking=no -o UserKnownHostsFile=/dev/null -i ${KEY_FOLDER}/${QIA_KEY_FILE} -r ${IMAGE_USER_server}:/image/*/day1/${BATCH_BARCODE}/${FORM_BARCODE}/*.TIF ${QIA_FOLDER}
    
 
  else
-  echo "${batch_barcode}${form_barcode} Already have processed images ${form_image_folder_path} - skipping copy to QIA"
+   f_logInfo "${BATCH_BARCODE}${FORM_BARCODE} Already have processed images ${FORM_IMAGE_FOLDER_PATH} - skipping copy to QIA"
  fi
-
  
 done
 
-rm -f ${barcode_list}
+rm -f ${BARCODE_LIST}

--- a/fes-batch/qia/qia-run.sh
+++ b/fes-batch/qia/qia-run.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+local_image_dir=/apps/fes/qia/images
+dps_image_dir=/apps/fes/qia/breaches/Work
+image_user=${QIA_IMAGE_USER}
+image_server=${QIA_IMAGE_SERVER}
+image_user_server=${image_user}@${image_server}
+db_query_script=./db_queryqia
+db_query_output=/tmp/mw_unload
+barcode_list=barcodes.out
+
+cd /apps/fes/qia
+
+# Obtain list of form barcodes that have not yet been through sort
+date
+echo "Querying for outstanding barcodes"
+# TODO - use key file
+ssh ${image_user_server} ${db_query_script}
+scp ${image_user_server}:${db_query_output} ${barcode_list} 
+sed -i 's/ $//g' ${barcode_list}
+sed -i 's/ /:/g' ${barcode_list}
+
+echo
+date
+echo "Query for outstanding barcodes completed"
+wc -l ${barcode_list}
+
+# Iterate through list - checking if we already have the images
+for four_fields in `cat ${barcode_list}`
+do
+
+ batch_barcode=${four_fields%%:*}
+
+ three_fields=${four_fields#*:}
+ form_barcode=${three_fields%%:*}
+
+ two_fields=${three_fields#*:}
+ company_num=${two_fields%%:*}
+
+ doc_type=${two_fields##*:}
+
+ date
+ echo "Processing batch ${batch_barcode} document ${form_barcode} company ${company_num} type ${doc_type}"
+
+
+ # Ensure batch folder exists
+ batch_folder=${local_image_dir}/${batch_barcode}
+ mkdir -p ${batch_folder}
+ qia_folder=${dps_image_dir}/${batch_barcode}_${form_barcode}_${company_num}_${doc_type}
+
+ # Path to form image folder
+ form_image_folder_path=${batch_folder}/${form_barcode}
+
+ # Does form image folder exist - if not, copy images
+ if [ ! -d ${form_image_folder_path} ]; then
+
+   mkdir -p ${qia_folder}
+   chmod 777 ${qia_folder}
+
+   echo "${batch_barcode}${form_barcode}${company_num}${doc_type} Existing image folder not found: ${form_image_folder_path}"
+   echo "${batch_barcode}${form_barcode}${company_num}${doc_type}  Getting image from ${image_user_server}:/image/*/day1/${batch_barcode}/${form_barcode}"
+ 
+   mkdir -p ${form_image_folder_path}
+   #scp -r ${image_user_server}:/image/*/day1/${batch_barcode}/${form_barcode}/*.TIF ${qia_folder}
+   
+
+ else
+  echo "${batch_barcode}${form_barcode} Already have processed images ${form_image_folder_path} - skipping copy to QIA"
+ fi
+
+ 
+done
+
+rm -f ${barcode_list}


### PR DESCRIPTION
Add scripts that implement the current functionality hosted on-prem on ch-jfil-pl1 that:
- query the DPS informix DB for images that need manual review
- copies the images to the chfas-sl2:/vol/image_breaches/Work folder so that users can review them
- tracks which images have already been copied to avoid re-copying them
- deletes images in chfas-sl2:/vol/image_breaches/Release each evening

The on-prem automatic OCR checking functionality has been removed, as that is no longer needed.  Only the manual review functionality remains.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1307