### PR TITLE
Dockerfile update to have latest version of java (21) and fes-file-loader (java 21 build - V2.0.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,52 @@
-ARG IMAGE_VERSION="latest"
-FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-runtime-21:${IMAGE_VERSION}
+# Using the newer Java 21 runtime image
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0
 
+ARG ARTIFACTORY_URL
+ARG ARTIFACTORY_USERNAME
+ARG ARTIFACTORY_PASSWORD
+
+# Environment variables
 ENV FES_HOME=/apps/fes \
-    ARTIFACTORY_BASE_URL=https://artifactory.companieshouse.gov.uk/artifactory/virtual-release
+    ARTIFACTORY_BASE_URL=${ARTIFACTORY_URL}/virtual-release
 
-RUN yum -y install gettext && \
-    yum -y install cronie && \
-    yum -y install oracle-instantclient-release-el7 && \
-    yum -y install oracle-instantclient-basic && \
-    yum -y install oracle-instantclient-sqlplus && \
-    yum -y install https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm && \
-    yum -y install openssh-clients && \
-    yum --enablerepo ol7_optional_latest install -y sharutils && \
-    yum -y install msmtp && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+# Install required packages (for Oracle Linux 8 base)
+RUN dnf install -y oracle-instantclient-release-el8 && \
+    dnf install -y \
+        oracle-instantclient-basic \
+        oracle-instantclient-sqlplus \
+        gettext \
+        cronie \
+        openssh-clients \
+        xmlstarlet \
+        dos2unix \
+        jq \
+        ftp && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
+# Set up FES home and user
 RUN mkdir -p /apps && \
     chmod a+xr /apps && \
     useradd -u 2001 -d ${FES_HOME} -m -s /bin/bash fes
 
 USER fes
 
-# Copy all batch jobs to FES_HOME
+# Copy batch jobs
 COPY --chown=fes fes-batch ${FES_HOME}/
 
-# Download the batch libs and set permission on scripts
+# Download the batch libs and set permissions
 RUN mkdir -p ${FES_HOME}/libs && \
-    cd ${FES_HOME}/libs && \
-    curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/fes-file-loader/2.0.0/fes-file-loader-2.0.0.jar -o ../fes-file-loader/fes-file-loader.jar && \
+    mkdir -p ${FES_HOME}/fes-file-loader && \
+    curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" \
+        "${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/fes-file-loader/2.0.0/fes-file-loader-2.0.0.jar" \
+        -o "${FES_HOME}/fes-file-loader/fes-file-loader.jar" && \
     chmod -R 750 ${FES_HOME}/*
 
+# Set working directory
 WORKDIR $FES_HOME
+
+# Use root to allow future maintenance if needed
 USER root
+
+# Default command
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.5
+ARG IMAGE_VERSION="latest"
+FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-runtime-21:${IMAGE_VERSION}
 
 ENV FES_HOME=/apps/fes \
     ARTIFACTORY_BASE_URL=https://artifactory.companieshouse.gov.uk/artifactory/virtual-release
@@ -27,7 +28,7 @@ COPY --chown=fes fes-batch ${FES_HOME}/
 # Download the batch libs and set permission on scripts
 RUN mkdir -p ${FES_HOME}/libs && \
     cd ${FES_HOME}/libs && \
-    curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/fes-file-loader/1.2.0/fes-file-loader-1.2.0.jar -o ../fes-file-loader/fes-file-loader.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/fes-file-loader/2.0.0/fes-file-loader-2.0.0.jar -o ../fes-file-loader/fes-file-loader.jar && \
     chmod -R 750 ${FES_HOME}/*
 
 WORKDIR $FES_HOME


### PR DESCRIPTION
Dockerfile update to have latest version of java (21) and fes-file-loader (java 21 build - V2.0.0)

```
First docker build in local : 
---------------------------

Sending build context to Docker daemon  2.759MB
Step 1/14 : FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0
 ---> eaf9f474da59
Step 2/14 : ARG ARTIFACTORY_URL
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in 8092e3ea06b1
 ---> Removed intermediate container 8092e3ea06b1
 ---> 3fb5343800c3
Step 3/14 : ARG ARTIFACTORY_USERNAME
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in cf35f55eb5ec
 ---> Removed intermediate container cf35f55eb5ec
 ---> beedb9781a9f
Step 4/14 : ARG ARTIFACTORY_PASSWORD
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in c9defcdde3bb
 ---> Removed intermediate container c9defcdde3bb
 ---> 1d0a462f608f
Step 5/14 : ENV FES_HOME=/apps/fes     ARTIFACTORY_BASE_URL=${ARTIFACTORY_URL}/virtual-release
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in f2d159a0897a
 ---> Removed intermediate container f2d159a0897a
 ---> 24cbfee444b5
Step 6/14 : RUN dnf install -y oracle-instantclient-release-el8 &&     dnf install -y         oracle-instantclient-basic         oracle-instantclient-sqlplus         gettext         cronie         openssh-clients         xmlstarlet         dos2unix         jq         ftp &&     dnf clean all &&     rm -rf /var/cache/dnf
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in b69ff4745c4d
Oracle Linux 8 BaseOS Latest (x86_64)            15 MB/s | 122 MB     00:08    
Oracle Linux 8 Application Stream (x86_64)       10 MB/s |  74 MB     00:07    
Last metadata expiration check: 0:00:13 ago on Fri 14 Nov 2025 10:26:01 UTC.
Dependencies resolved.
================================================================================
 Package                           Arch    Version     Repository          Size
================================================================================
Installing:
 oracle-instantclient-release-el8  x86_64  1.0-2.el8   ol8_baseos_latest   18 k

Transaction Summary
================================================================================
Install  1 Package

Total download size: 18 k
Installed size: 18 k
Downloading Packages:
oracle-instantclient-release-el8-1.0-2.el8.x86_  60 kB/s |  18 kB     00:00    
--------------------------------------------------------------------------------
Total                                            59 kB/s |  18 kB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Installing       : oracle-instantclient-release-el8-1.0-2.el8.x86_64      1/1 
  Running scriptlet: oracle-instantclient-release-el8-1.0-2.el8.x86_64      1/1 
  Verifying        : oracle-instantclient-release-el8-1.0-2.el8.x86_64      1/1 

Installed:
  oracle-instantclient-release-el8-1.0-2.el8.x86_64                             

Complete!
Oracle Instant Client 21 for Oracle Linux 8 (x8  75 kB/s |  42 kB     00:00    
Package openssh-clients-8.0p1-26.0.1.el8_10.x86_64 is already installed.
Dependencies resolved.
=================================================================================================
 Package                        Arch    Version                 Repository                   Size
=================================================================================================
Installing:
 cronie                         x86_64  1.5.2-10.el8            ol8_baseos_latest           118 k
 dos2unix                       x86_64  7.4.0-3.el8             ol8_baseos_latest           241 k
 ftp                            x86_64  0.17-78.el8             ol8_appstream                70 k
 gettext                        x86_64  0.19.8.1-17.el8         ol8_baseos_latest           1.1 M
 jq                             x86_64  1.6-11.el8_10           ol8_appstream               202 k
 oracle-instantclient-basic     x86_64  21.20.0.0.0-1.el8       ol8_oracle_instantclient21   53 M
 oracle-instantclient-sqlplus   x86_64  21.20.0.0.0-1.el8       ol8_oracle_instantclient21  710 k
 xmlstarlet                     x86_64  1.6.1-20.el8            ol8_appstream                71 k
Installing dependencies:
 cronie-anacron                 x86_64  1.5.2-10.el8            ol8_baseos_latest            41 k
 crontabs                       noarch  1.11-17.20190603git.el8 ol8_baseos_latest            25 k
 gettext-libs                   x86_64  0.19.8.1-17.el8         ol8_baseos_latest           312 k
 libcroco                       x86_64  0.6.12-4.el8_2.1        ol8_baseos_latest           113 k
 libgomp                        x86_64  8.5.0-28.0.1.el8_10     ol8_baseos_latest           219 k
 libxslt                        x86_64  1.1.32-6.3.0.1.el8_10   ol8_baseos_latest           249 k
 oniguruma                      x86_64  6.8.2-3.el8             ol8_appstream               187 k

Transaction Summary
=================================================================================================
Install  15 Packages

Total download size: 57 M
Installed size: 252 M
Downloading Packages:
(1/15): cronie-1.5.2-10.el8.x86_64.rpm          295 kB/s | 118 kB     00:00    
(2/15): oracle-instantclient-sqlplus-21.20.0.0. 1.6 MB/s | 710 kB     00:00    
(3/15): cronie-anacron-1.5.2-10.el8.x86_64.rpm  845 kB/s |  41 kB     00:00    
(4/15): crontabs-1.11-17.20190603git.el8.noarch 761 kB/s |  25 kB     00:00    
(5/15): dos2unix-7.4.0-3.el8.x86_64.rpm         2.9 MB/s | 241 kB     00:00    
(6/15): gettext-libs-0.19.8.1-17.el8.x86_64.rpm 3.5 MB/s | 312 kB     00:00    
(7/15): libcroco-0.6.12-4.el8_2.1.x86_64.rpm    1.7 MB/s | 113 kB     00:00    
(8/15): gettext-0.19.8.1-17.el8.x86_64.rpm      4.3 MB/s | 1.1 MB     00:00    
(9/15): libgomp-8.5.0-28.0.1.el8_10.x86_64.rpm  3.5 MB/s | 219 kB     00:00    
(10/15): libxslt-1.1.32-6.3.0.1.el8_10.x86_64.r 2.6 MB/s | 249 kB     00:00    
(11/15): ftp-0.17-78.el8.x86_64.rpm             998 kB/s |  70 kB     00:00    
(12/15): jq-1.6-11.el8_10.x86_64.rpm            5.2 MB/s | 202 kB     00:00    
(13/15): oniguruma-6.8.2-3.el8.x86_64.rpm       2.6 MB/s | 187 kB     00:00    
(14/15): xmlstarlet-1.6.1-20.el8.x86_64.rpm     1.0 MB/s |  71 kB     00:00    
(15/15): oracle-instantclient-basic-21.20.0.0.0 9.1 MB/s |  53 MB     00:05    
--------------------------------------------------------------------------------
Total                                           9.7 MB/s |  57 MB     00:05     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Installing       : cronie-anacron-1.5.2-10.el8.x86_64                    1/15 
  Running scriptlet: cronie-anacron-1.5.2-10.el8.x86_64                    1/15 
  Installing       : cronie-1.5.2-10.el8.x86_64                            2/15 
  Running scriptlet: cronie-1.5.2-10.el8.x86_64                            2/15 
  Installing       : crontabs-1.11-17.20190603git.el8.noarch               3/15 
  Installing       : libgomp-8.5.0-28.0.1.el8_10.x86_64                    4/15 
  Running scriptlet: libgomp-8.5.0-28.0.1.el8_10.x86_64                    4/15 
  Installing       : libcroco-0.6.12-4.el8_2.1.x86_64                      5/15 
  Running scriptlet: libcroco-0.6.12-4.el8_2.1.x86_64                      5/15 
  Installing       : gettext-libs-0.19.8.1-17.el8.x86_64                   6/15 
  Installing       : oniguruma-6.8.2-3.el8.x86_64                          7/15 
  Running scriptlet: oniguruma-6.8.2-3.el8.x86_64                          7/15 
  Installing       : libxslt-1.1.32-6.3.0.1.el8_10.x86_64                  8/15 
  Installing       : oracle-instantclient-basic-21.20.0.0.0-1.el8.x86_6    9/15 
  Running scriptlet: oracle-instantclient-basic-21.20.0.0.0-1.el8.x86_6    9/15 
  Installing       : oracle-instantclient-sqlplus-21.20.0.0.0-1.el8.x86   10/15 
  Running scriptlet: oracle-instantclient-sqlplus-21.20.0.0.0-1.el8.x86   10/15 
  Installing       : xmlstarlet-1.6.1-20.el8.x86_64                       11/15 
  Installing       : jq-1.6-11.el8_10.x86_64                              12/15 
  Installing       : gettext-0.19.8.1-17.el8.x86_64                       13/15 
  Running scriptlet: gettext-0.19.8.1-17.el8.x86_64                       13/15 
  Installing       : ftp-0.17-78.el8.x86_64                               14/15 
  Installing       : dos2unix-7.4.0-3.el8.x86_64                          15/15 
  Running scriptlet: dos2unix-7.4.0-3.el8.x86_64                          15/15 
  Verifying        : oracle-instantclient-basic-21.20.0.0.0-1.el8.x86_6    1/15 
  Verifying        : oracle-instantclient-sqlplus-21.20.0.0.0-1.el8.x86    2/15 
  Verifying        : cronie-1.5.2-10.el8.x86_64                            3/15 
  Verifying        : cronie-anacron-1.5.2-10.el8.x86_64                    4/15 
  Verifying        : crontabs-1.11-17.20190603git.el8.noarch               5/15 
  Verifying        : dos2unix-7.4.0-3.el8.x86_64                           6/15 
  Verifying        : gettext-0.19.8.1-17.el8.x86_64                        7/15 
  Verifying        : gettext-libs-0.19.8.1-17.el8.x86_64                   8/15 
  Verifying        : libcroco-0.6.12-4.el8_2.1.x86_64                      9/15 
  Verifying        : libgomp-8.5.0-28.0.1.el8_10.x86_64                   10/15 
  Verifying        : libxslt-1.1.32-6.3.0.1.el8_10.x86_64                 11/15 
  Verifying        : ftp-0.17-78.el8.x86_64                               12/15 
  Verifying        : jq-1.6-11.el8_10.x86_64                              13/15 
  Verifying        : oniguruma-6.8.2-3.el8.x86_64                         14/15 
  Verifying        : xmlstarlet-1.6.1-20.el8.x86_64                       15/15 

Installed:
  cronie-1.5.2-10.el8.x86_64                                                    
  cronie-anacron-1.5.2-10.el8.x86_64                                            
  crontabs-1.11-17.20190603git.el8.noarch                                       
  dos2unix-7.4.0-3.el8.x86_64                                                   
  ftp-0.17-78.el8.x86_64                                                        
  gettext-0.19.8.1-17.el8.x86_64                                                
  gettext-libs-0.19.8.1-17.el8.x86_64                                           
  jq-1.6-11.el8_10.x86_64                                                       
  libcroco-0.6.12-4.el8_2.1.x86_64                                              
  libgomp-8.5.0-28.0.1.el8_10.x86_64                                            
  libxslt-1.1.32-6.3.0.1.el8_10.x86_64                                          
  oniguruma-6.8.2-3.el8.x86_64                                                  
  oracle-instantclient-basic-21.20.0.0.0-1.el8.x86_64                           
  oracle-instantclient-sqlplus-21.20.0.0.0-1.el8.x86_64                         
  xmlstarlet-1.6.1-20.el8.x86_64                                                

Complete!
24 files removed
 ---> Removed intermediate container b69ff4745c4d
 ---> 3c11c614663e
Step 7/14 : RUN mkdir -p /apps &&     chmod a+xr /apps &&     useradd -u 2001 -d ${FES_HOME} -m -s /bin/bash fes
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in d1ba7e5f2b8f
 ---> Removed intermediate container d1ba7e5f2b8f
 ---> 11d2225cc9fa
Step 8/14 : USER fes
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in 6b56fb46f68f
 ---> Removed intermediate container 6b56fb46f68f
 ---> f8e516c42f46
Step 9/14 : COPY --chown=fes fes-batch ${FES_HOME}/
 ---> c0b21f7308dc
Step 10/14 : COPY --chown=fes data ${FES_HOME}/data
 ---> 4e35b28d6ca3
Step 11/14 : RUN mkdir -p ${FES_HOME}/libs &&     mkdir -p ${FES_HOME}/fes-file-loader &&     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}"         "${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/fes-file-loader/2.0.0/fes-file-loader-2.0.0.jar"         -o "${FES_HOME}/fes-file-loader/fes-file-loader.jar" &&     chmod -R 750 ${FES_HOME}/*
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in ce7688da0962
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 11.6M  100 11.6M    0     0  6335k      0  0:00:01  0:00:01 --:--:-- 14.6M
 ---> Removed intermediate container ce7688da0962
 ---> 77434443ebb8
Step 12/14 : WORKDIR $FES_HOME
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in ea50205fe8cf
 ---> Removed intermediate container ea50205fe8cf
 ---> a421c472b489
Step 13/14 : USER root
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in 562f450aaf8b
 ---> Removed intermediate container 562f450aaf8b
 ---> f6e93897572e
Step 14/14 : CMD ["bash"]
 ---> [Warning] The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 ---> Running in 958f651ec08f
 ---> Removed intermediate container 958f651ec08f
 ---> d24d29e598a2
[Warning] One or more build-args [ADMIN_PASSWORD] were not consumed
Successfully built d24d29e598a2
Successfully tagged chips-fes-batch:latest



subsequent docker build in local : 
-------------------------------


[+] Building 61.5s (13/13) FINISHED                                                                                                                                                                                           docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 1.57kB                                                                                                                                                                                                        0.0s
 => [internal] load metadata for 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0                                                                                                                                              0.6s
 => [auth] sharing credentials for 300288021642.dkr.ecr.eu-west-2.amazonaws.com                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                                                               0.0s
 => CACHED [1/7] FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0@sha256:c2fc00f8de8ae9c1c5df00617afb6c8fc2dcb7cf202f2def5504279020f79caf                                                                                 0.0s
 => => resolve 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0@sha256:c2fc00f8de8ae9c1c5df00617afb6c8fc2dcb7cf202f2def5504279020f79caf                                                                                        0.0s
 => [internal] load build context                                                                                                                                                                                                             0.1s
 => => transferring context: 2.48MB                                                                                                                                                                                                           0.1s
 => [2/7] RUN dnf install -y oracle-instantclient-release-el8 &&     dnf install -y         oracle-instantclient-basic         oracle-instantclient-sqlplus         gettext         cronie         openssh-clients         xmlstarlet        57.7s
 => [3/7] RUN mkdir -p /apps &&     chmod a+xr /apps &&     useradd -u 2001 -d /apps/fes -m -s /bin/bash fes                                                                                                                                  0.2s 
 => [4/7] COPY --chown=fes fes-batch /apps/fes/                                                                                                                                                                                               0.0s 
 => [5/7] COPY --chown=fes data /apps/fes/data                                                                                                                                                                                                0.0s 
 => [6/7] RUN mkdir -p /apps/fes/libs &&     mkdir -p /apps/fes/fes-file-loader &&     curl -L -u "email:<pwd>"         "https://chartifacts.jfrog.io  2.5s 
 => [7/7] WORKDIR /apps/fes                                                                                                                                                                                                                   0.0s 
 => exporting to image                                                                                                                                                                                                                        0.4s 
 => => exporting layers                                                                                                                                                                                                                       0.4s 
 => => writing image sha256:c28ac8a744d5b8d529a5dd0754046c1ab891ab60d39d633a0f8afc9e1713356a                                                                                                                                                  0.0s 
 => => naming to docker.io/library/chips-fes-batch  
```